### PR TITLE
Add linker optimization flag as recommended by compiler

### DIFF
--- a/sys/ViGEmBus.vcxproj
+++ b/sys/ViGEmBus.vcxproj
@@ -147,6 +147,7 @@
     </Inf>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)ntstrsafe.lib;$(DDK_LIB_PATH)wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <ClCompile>
       <WppRecorderEnabled>true</WppRecorderEnabled>

--- a/sys/ViGEmBus.vcxproj
+++ b/sys/ViGEmBus.vcxproj
@@ -161,6 +161,7 @@
     </Inf>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)ntstrsafe.lib;$(DDK_LIB_PATH)wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <ClCompile>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>


### PR DESCRIPTION
I tested the most recent source code but performance seemed to have degraded some. After enabling a linker option recommended by the compiler, performance issues went away. Output performance is now slightly better than with the previous version of the driver that I was using (commit 5b861c9287dcebaf710232562911713b0ba7f3be). Here is the original text that led me to make this change.

```
1>busenum.obj : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
```