### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: ViGEm.ViGEmBus
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: ViGEm.ViGEmBus
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them. This is in line with the PR in HidHide (https://github.com/ViGEm/HidHide/pull/80).

Before merging this:
- Follow the steps in https://github.com/ViGEm/HidHide/pull/80. See that PR for the rest of the information.

Resolves #141